### PR TITLE
replace executor with pollster

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ categories = ["asynchronous", "concurrency"]
 keywords = ["async", "channel", "oneshot", "reusable", "futures"]
 
 [dev-dependencies]
-executor = "0.8"
+pollster = "0.3"
 
 [target.'cfg(multishot_loom)'.dependencies]
 loom = "0.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,10 +9,10 @@
 //!
 //!
 //! ```
-//! # use executor;
+//! # use pollster;
 //! use std::thread;
 //!
-//! # executor::run(
+//! # pollster::block_on(
 //! async {
 //!     let (s, mut r) = multishot::channel();
 //!


### PR DESCRIPTION
`cargo miri test` passes with this change, resolving https://github.com/asynchronics/multishot/issues/1.
Of course, does not functionally change anything about this crate, but makes it so a quick miri check does not scare away potential users.